### PR TITLE
Call translator directly

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,11 +25,7 @@ return [
         'before@system/intl' => function ($event, $request) use ($app) {
 
             $locale = $request->get('locale');
-            $app->extend('translator', function ($translator) use ($locale) {
-
-                $translator->addResource('php', __DIR__ . '/languages/en_US/messages.php', $locale);
-                return $translator;
-            });
+            $app['translator']->addResource('php', __DIR__ . '/languages/en_US/messages.php', $locale);
 
         },
 


### PR DESCRIPTION
The `$app['translator']` closure is already set to a Translator instance when eg `__()`  is called in the boot event.